### PR TITLE
Add support for mixins

### DIFF
--- a/src/Foundation/res/_foundation.scss
+++ b/src/Foundation/res/_foundation.scss
@@ -1,0 +1,1 @@
+@import "mixins/breakpoints";

--- a/src/Foundation/res/mixins/_breakpoints.scss
+++ b/src/Foundation/res/mixins/_breakpoints.scss
@@ -1,0 +1,40 @@
+$mobile: 0px !default;
+$phablet: 512px !default;
+$tablet: 768px !default;
+$desktop: 1024px !default;
+$hd: 1280px !default;
+
+// Hard code this here just to prevent breaking of the mixins
+$breakpoints: (
+  'mobile': $mobile,
+  'phablet': $phablet,
+  'tablet': $tablet,
+  'desktop': $desktop,
+  'hd': $hd
+);
+
+@function nextKey($currentValue, $mapped-list) {
+  @return nth(map_keys($mapped-list), (index(map_keys($mapped-list), $currentValue)) + 1);
+}
+
+@mixin breakpoint($breakpoint) {
+
+  $index: index(map-keys($breakpoints), $breakpoint);
+
+  @if $index {
+    @if $index == 1 {
+      @media (max-width: map-get($breakpoints, nextKey($breakpoint, $breakpoints)) - 1) {
+        @content;
+      }
+    } @else if $index < length($breakpoints) {
+      @media screen and (min-width: map-get($breakpoints, $breakpoint)) and (max-width: map-get($breakpoints, nextKey($breakpoint, $breakpoints)) - 1) {
+        @content;
+      }
+    } @else if ($index == length($breakpoints)) {
+      @media screen and (min-width: map-get($breakpoints, $breakpoint)) {
+        @content;
+      }
+    }
+
+  }
+}

--- a/src/Foundation/res/mixins/_breakpoints.scss
+++ b/src/Foundation/res/mixins/_breakpoints.scss
@@ -17,13 +17,17 @@ $breakpoints: (
   @return nth(map_keys($mapped-list), (index(map_keys($mapped-list), $currentValue)) + 1);
 }
 
-@mixin breakpoint($breakpoint) {
+@mixin breakpoint($breakpointValue) {
+
+  // (up down or only)
+  $direction: if(length($breakpointValue) > 1, nth($breakpointValue, 2), up);
+  $breakpoint: nth($breakpointValue, 1);
 
   $index: index(map-keys($breakpoints), $breakpoint);
 
-  @if $index {
+  @if $direction == 'only' {
     @if $index == 1 {
-      @media (max-width: map-get($breakpoints, nextKey($breakpoint, $breakpoints)) - 1) {
+      @media screen and (max-width: map-get($breakpoints, nextKey($breakpoint, $breakpoints)) - 1) {
         @content;
       }
     } @else if $index < length($breakpoints) {
@@ -35,6 +39,27 @@ $breakpoints: (
         @content;
       }
     }
-
+  } @else if ($direction == 'up') {
+    @media screen and (min-width: map-get($breakpoints, $breakpoint)) {
+      @content;
+    }
+  } @else if ($direction == 'down') {
+    @media screen and (max-width: map-get($breakpoints, nextKey($breakpoint, $breakpoints)) - 1) {
+      @content;
+    }
+  } @else {
+    @if $index == 1 {
+      @media screen and (max-width: map-get($breakpoints, nextKey($breakpoint, $breakpoints)) - 1) {
+        @content;
+      }
+    } @else if $index < length($breakpoints) {
+      @media screen and (min-width: map-get($breakpoints, $breakpoint)) and (max-width: map-get($breakpoints, nextKey($breakpoint, $breakpoints)) - 1) {
+        @content;
+      }
+    } @else if ($index == length($breakpoints)) {
+      @media screen and (min-width: map-get($breakpoints, $breakpoint)) {
+        @content;
+      }
+    }
   }
 }


### PR DESCRIPTION
usage example in fusion: 


```
@import "../../Foundation/res/foundation";

@include breakpoint(mobile only) {
	content
}
```

Will only affect mobile breakpoint defined between mobile and phablet

```
@import "../../Foundation/res/foundation";

@include breakpoint(phablet down) {
	content
}
```
Will affect phablet and mobile as we can point down

```
@inlcude breakpoint(tablet up) {
	content
}
```
Will affect tablet and everything above


```
@inlcude breakpoint(tablet) {
	content
}
```
Will act similar to up affecting all sizes declared above.

The first param will accept anything in the named $breakpoints so we can scale easily. by adding any breakpoint we want eg 'XXXL' => 1440px then we can call @include breakpoint(XXXL) {
}

example generated input and output
```
@inlcude breakpoint(mobile down) {
  .selector {
    background-color: red
  }
}


@media screen and (max-width: 511px) {
  .selector {
    background-color: red
  }
}
```

```
@include breakpoint(desktop) {
  background-color: blue;
}

@media screen and (min-width: 1024px) {
  .banner {
    background-color: #00f
  }
}
```


```
@include breakpoint(desktop only) {
  background-color: orange;
}

@media screen and (min-width: 1024px) and (max-width: 1279px) {
  .banner {
    background-color: orange
  }
}
```