### PR TITLE
- Create a function to allow passing var to the RGB and RGBA sass

### DIFF
--- a/src/Foundation/res/_foundation.scss
+++ b/src/Foundation/res/_foundation.scss
@@ -1,1 +1,7 @@
+//Variables
+
+//Functions
+@import "/functions/color";
+
+// Mixins
 @import "mixins/breakpoints";

--- a/src/Foundation/res/functions/_color.scss
+++ b/src/Foundation/res/functions/_color.scss
@@ -1,0 +1,22 @@
+@function rgb($r, $g: null, $b: null ) {
+  @if ($g == null) {
+    @return unquote('rgb(#{$r})');
+  }
+
+  @if ($g and $b) {
+    @return unquote('rgb(#{$r}, #{$g}, #{$b})');
+  }
+
+  @error "wrong number of arguments";
+}
+
+@function rgba($r, $g, $b: null, $a: null ) {
+  @if ($b == null) {
+    @return unquote('rgba(#{$r}, #{$g})');
+  }
+
+
+  @if ($b and $a) {
+    @return unquote('rgba(#{$r}, #{$g}, #{$b}, #{$a})');
+  }
+}


### PR DESCRIPTION
This will stop sass preventing compile because of only passing one argument to the build in rgb, rgba function. 